### PR TITLE
2023-1-4 pr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 
 target/
-
+*.xyz
 Cargo.lock
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ clap = {version = "^4", features=["derive"]}
 rand = "*"
 GSL = "*"
 ndarray = "*"
-ndarray-linalg = { version = "0.13" }
 
 [profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,21 @@
 [package]
 name = "soap"
 version = "0.0.1"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-clap = "*"
+clap = {version = "^4", features=["derive"]}
 rand = "*"
 GSL = "*"
 ndarray = "*"
+ndarray-linalg = { version = "0.13" }
+
+[profile.release]
+panic = "abort"
+lto = true
+codegen-units = 1
+strip = true
+opt-level = "s"
+
+[profile.dev]
+opt-level = "s"

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ cargo build --release
 
 
 ##  Usage  
-Execute the binary built in the *targets/release/* directory. For example to generate the 'SOAP vector' for the H-atom density in a methane molecule:
+Execute the binary built in the *targets/release/* directory. For example to generate the 'SOAP vector' for the density of all of the Na and Cl in a Nacl lattice:
 
 ```bash
-target/release/soap methane.xyz 0 H
+target/release/soap -f=./nacl_test.xyz -c=0 -s Na -s  Cl
 ```
 
 where the first argument is the .xyz structure file, the second the atom index of the origin and the third the element comprising the neighbours. See the help for all options:

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -19,8 +19,8 @@ impl CartesianCoordinate{
         let r: f64 = self.sq_distance().sqrt();
 
         SphericalPolarCoordinate{r:     r,
-                                 theta: self.y.atan2(self.x),
-                                 phi:   (self.z / r).acos()}
+                                 phi: self.y.atan2(self.x),
+                                 theta:   (self.z / r).acos()}
     }
 
     pub fn shift_then_to_polar(&self, 
@@ -99,8 +99,8 @@ mod tests{
         let coordinate = CartesianCoordinate{x: 0.0, y: 0.0, z: 1.0 }.to_polar();
         
         assert!(is_close(coordinate.r, 1.0, 1E-8));
-        assert!(is_close(coordinate.theta, 0.0, 1E-8));
         assert!(is_close(coordinate.phi, 0.0, 1E-8));
+        assert!(is_close(coordinate.theta, 0.0, 1E-8));
 
         // non-unity distance
         let coordinate = CartesianCoordinate{x: 1.0, y: 1.0, z: 0.0 }.to_polar();
@@ -109,14 +109,14 @@ mod tests{
         // non-zero angles
         let coordinate = CartesianCoordinate{x: 1.0, y: 0.0, z: 0.0 }.to_polar();
         assert!(is_close(coordinate.r, 1.0, 1E-8));
-        assert!(is_close(coordinate.theta, 0.0, 1E-8));
-        assert!(is_close(coordinate.phi, FRAC_PI_2, 1E-8));
+        assert!(is_close(coordinate.phi, 0.0, 1E-8));
+        assert!(is_close(coordinate.theta, FRAC_PI_2, 1E-8));
 
         // non-positive quadrant
         let coordinate = CartesianCoordinate{x: -1.0, y: 0.0, z: 0.0}.to_polar();
         assert!(is_close(coordinate.r, 1.0, 1E-8));
-        assert!(is_close(coordinate.theta.abs(), PI, 1E-8));
-        assert!(is_close(coordinate.phi, FRAC_PI_2, 1E-8));
+        assert!(is_close(coordinate.phi.abs(), PI, 1E-8));
+        assert!(is_close(coordinate.theta, FRAC_PI_2, 1E-8));
     }
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ struct Cli {
     #[arg(
         long,
         default_value_t = 0.5,
-        help = "Smoothness of the neihgbour denisty, in Å"
+        help = "Smoothness of the neighbour denisty, in Å"
     )]
     sigma: f64,
 }

--- a/src/soap.rs
+++ b/src/soap.rs
@@ -64,13 +64,15 @@ fn c_nlm(sphr_coords: &Vec<SphericalPolarCoordinate>,
 }
 
 
-pub fn power_spectrum(structure:      &Structure,
-                      atom_idx:       usize,
-                      nbr_element:    &str,
-                      n_max:          usize,
-                      l_max:          usize,
-                      r_cut:          f64,
-                      sigma_at:       f64) -> Vec<f64>{
+pub fn power_spectrum(
+    structure: &Structure,
+    atom_idx: usize,
+    species: &Vec<String>,
+    n_max: usize,
+    l_max: usize,
+    r_cut: f64,
+    sigma_at: f64,
+) -> Vec<f64> {
     /*
     Compute the vector comprising the elements of the power spectrum
     p_nn'l, where n, n'∈[1, n_max] and l ∈ [0, l_max]. n_max must be at
@@ -83,11 +85,11 @@ pub fn power_spectrum(structure:      &Structure,
 
         nbr_element (str): String of the element about which to expand
                            the neighbour density e.g. "C"
-        
+
         n_max (int): Maximum radial expansion basis (>1)
 
         l_max (int): Maximum angular expansion basis (≥0)
-    
+
         r_cut (float): Cut-off distance used in the construction of the
                        radial basis functions
 
@@ -96,61 +98,67 @@ pub fn power_spectrum(structure:      &Structure,
     Returns:
         (vector(float)): Concatenated elements
     */
-   
-    let sphr_nbrs = structure.sphr_neighbours(atom_idx, 
-                                              nbr_element,
-                                              r_cut);
- 
+
     let mut rbfs: RadialBasisFunctions = Default::default();
     rbfs.construct(n_max, l_max, r_cut);
 
     let mut c = vec![];
-    
-    for n in 1..=n_max{
-        let mut c_n = vec![];
-        
-        for l in 0..=l_max{
-            let mut c_nl = vec![];
-            let l_i32 = l as i32;
-            
-            for m_idx in 0..=2*l{   // 2l + 1 terms
 
-                let m = (m_idx as i32) - l_i32;
-                c_nl.push(c_nlm(&sphr_nbrs, &rbfs, n, l, m, sigma_at));
+    for atom_number in species {
+        let mut cz = vec![];
+        let sphr_nbrs = structure.sphr_neighbours(atom_idx, atom_number, r_cut);
+        for n in 1..=n_max {
+            let mut c_n = vec![];
 
-            }// m
-            c_n.push(c_nl);
+            for l in 0..=l_max {
+                let mut c_nl = vec![];
+                let l_i32 = l as i32;
 
-        }// l
-    
-        c.push(c_n);
-    }// n
+                for m_idx in 0..=2 * l {
+                    // 2l + 1 terms
 
- 
-    let mut p = Vec::<f64>::with_capacity(n_max * n_max * (l_max + 1));
+                    let m = (m_idx as i32) - l_i32;
+                    // let a = 1_f64 / (2_f64 * sigma_at.powi(2)); // 1/2σ^2s
+                    // let numerical_c_nlm = mc_integral(&sphr_nbrs, &rbfs, n, l, m, a);
+                    // c_nl.push(numerical_c_nlm);
 
-    for n in 1..=n_max{
-        for n_prime in n..=n_max{
-            for l in 0..=l_max{
+                    c_nl.push(c_nlm(&sphr_nbrs, &rbfs, n, l, m, sigma_at));
+                } // m
+                c_n.push(c_nl);
+            } // l
 
-                let mut sum_m = 0_f64;
-            
-                for m_idx in 0..=2*l{   // 2l + 1 terms
+            cz.push(c_n);
+        } // n
+        c.push(cz); // z
+    }
 
-                    sum_m += c[n-1][l][m_idx] * c[n_prime-1][l][m_idx]; 
-                    //println!("n = {}, l = {}, m = {}", n, l, (m_idx as i32)-l as i32); 
+    let mut p = Vec::<f64>::with_capacity(species.len() * n_max * n_max * (l_max + 1));
 
-                }// m
+    for zi in 0..species.len() {
+        for zj in 0..species.len() {
+            for n in 1..=n_max {
+                for n_prime in n..=n_max {
+                    for l in 0..=l_max {
+                        if zi <= zj {
+                            let mut sum_m = 0_f64;
 
-                p.push(sum_m / ((2*l + 1) as f64).sqrt())        
+                            for m_idx in 0..=2 * l {
+                                // 2l + 1 terms
 
-            }// l
-        }// n'
-    }// n
-   
+                                sum_m += c[zi][n - 1][l][m_idx] * c[zj][n_prime - 1][l][m_idx];
+                                // println!("n = {}, l = {}, m = {}", n, l, (m_idx as i32)-l as i32);
+                            } // m
+
+                            p.push(sum_m / ((2 * l + 1) as f64).sqrt())
+                        }
+                    } // l
+                } // n'
+            } // n
+        }
+    }
+
     p
 }
-
 
 
 /*
@@ -183,7 +191,91 @@ mod tests{
         (x - y).abs() <= atol
     }
 
-    
+    pub fn power_spectrum_old(structure:      &Structure,
+        atom_idx:       usize,
+        nbr_element:    &str,
+        n_max:          usize,
+        l_max:          usize,
+        r_cut:          f64,
+        sigma_at:       f64) -> Vec<f64>{
+        /*
+        Compute the vector comprising the elements of the power spectrum
+        p_nn'l, where n, n'∈[1, n_max] and l ∈ [0, l_max]. n_max must be at
+        least 2.
+
+        Arguments:
+        structure: strucutre (box/molecule/system) defining the geometry
+
+        atom_idx (int): Index of the atom to expand about
+
+        nbr_element (str): String of the element about which to expand
+                    the neighbour density e.g. "C"
+
+        n_max (int): Maximum radial expansion basis (>1)
+
+        l_max (int): Maximum angular expansion basis (≥0)
+
+        r_cut (float): Cut-off distance used in the construction of the
+                radial basis functions
+
+        sigma_at (float): Width of the Gaussians used in the SOAP
+
+        Returns:
+        (vector(float)): Concatenated elements
+        */
+
+        let sphr_nbrs = structure.sphr_neighbours(atom_idx, 
+                                        nbr_element,
+                                        r_cut);
+
+        let mut rbfs: RadialBasisFunctions = Default::default();
+        rbfs.construct(n_max, l_max, r_cut);
+
+        let mut c = vec![];
+
+        for n in 1..=n_max{
+            let mut c_n = vec![];
+
+            for l in 0..=l_max{
+                let mut c_nl = vec![];
+                let l_i32 = l as i32;
+
+                for m_idx in 0..=2*l{   // 2l + 1 terms
+
+                    let m = (m_idx as i32) - l_i32;
+                    c_nl.push(c_nlm(&sphr_nbrs, &rbfs, n, l, m, sigma_at));
+
+                }// m
+                c_n.push(c_nl);
+
+            }// l
+
+            c.push(c_n);
+        }// n
+
+
+        let mut p = Vec::<f64>::with_capacity(n_max * n_max * (l_max + 1));
+
+        for n in 1..=n_max{
+            for n_prime in n..=n_max{
+            for l in 0..=l_max{
+
+                let mut sum_m = 0_f64;
+
+                for m_idx in 0..=2*l{   // 2l + 1 terms
+                    sum_m += c[n-1][l][m_idx] * c[n_prime-1][l][m_idx]; 
+                    //println!("n = {}, l = {}, m = {}", n, l, (m_idx as i32)-l as i32); 
+                }// m
+
+                    p.push(sum_m / ((2*l + 1) as f64).sqrt())        
+
+                }// l
+            }// n'
+        }// n
+
+        p
+    }
+
     fn write_methane_xyz(i: usize){
         std::fs::write(format!("methane{}.xyz", i), 
                        "5\n\n\
@@ -257,7 +349,7 @@ mod tests{
         
 	    write_methane_xyz(0); 
  
-        let p = power_spectrum(&Structure::from("methane0.xyz"),
+        let p = power_spectrum_old(&Structure::from("methane0.xyz"),
                                0,          // Atom index to expand about
                                "H",        // Neighbour denisty
                                2,          // n_max
@@ -292,7 +384,7 @@ mod tests{
                        .expect("Failed to write methane.xyz!");
   
  
-        let p = power_spectrum(&Structure::from("methane_trns.xyz"),
+        let p = power_spectrum_old(&Structure::from("methane_trns.xyz"),
                                0, "H", 2, 0, 2.0_f64, 0.5_f64);        
  
         let p_expected = vec![0.07695406_f64, -0.24412914_f64, 0.7744755_f64];
@@ -318,7 +410,7 @@ mod tests{
                        .expect("Failed to write methane.xyz!");
   
  
-        let p = power_spectrum(&Structure::from("methane_rot.xyz"),
+        let p = power_spectrum_old(&Structure::from("methane_rot.xyz"),
                                0, "H", 2, 0, 2.0_f64, 0.5_f64);        
  
         let p_expected = vec![0.07695406_f64, -0.24412914_f64, 0.7744755_f64];
@@ -344,7 +436,7 @@ mod tests{
                        .expect("Failed to write methane.xyz!");
   
  
-        let p = power_spectrum(&Structure::from("methane_disp.xyz"),
+        let p = power_spectrum_old(&Structure::from("methane_disp.xyz"),
                                0, "H", 2, 0, 2.0_f64, 0.5_f64);        
  
         let p_expected = vec![0.07695406_f64, -0.24412914_f64, 0.7744755_f64];
@@ -532,13 +624,13 @@ mod tests{
                         H    -3.49516        0.77379        1.00295\n")
                        .expect("Failed to write methane.xyz!");
         
-        let p_0 = normalised(&power_spectrum(&Structure::from("methane3.xyz"),
+        let p_0 = normalised(&power_spectrum_old(&Structure::from("methane3.xyz"),
                                            0, "H", 6, 6, 6.0_f64, 0.5_f64)); 
 
-        let p_1 = normalised(&power_spectrum(&Structure::from("methane_short.xyz"),
+        let p_1 = normalised(&power_spectrum_old(&Structure::from("methane_short.xyz"),
                                               0, "H", 6, 6, 6.0_f64, 0.5_f64));         
         
-        let p_2 = normalised(&power_spectrum(&Structure::from("methane_long.xyz"),
+        let p_2 = normalised(&power_spectrum_old(&Structure::from("methane_long.xyz"),
                                     0, "H", 6, 6, 6.0_f64, 0.5_f64)); 
 
         let mut k_01 = 0_f64;

--- a/src/soap.rs
+++ b/src/soap.rs
@@ -83,8 +83,7 @@ pub fn power_spectrum(
 
         atom_idx (int): Index of the atom to expand about
 
-        nbr_element (str): String of the element about which to expand
-                           the neighbour density e.g. "C"
+        species (Vec<String>): The symbols of the elements to consider. e.g. H
 
         n_max (int): Maximum radial expansion basis (>1)
 
@@ -118,9 +117,6 @@ pub fn power_spectrum(
                     // 2l + 1 terms
 
                     let m = (m_idx as i32) - l_i32;
-                    // let a = 1_f64 / (2_f64 * sigma_at.powi(2)); // 1/2σ^2s
-                    // let numerical_c_nlm = mc_integral(&sphr_nbrs, &rbfs, n, l, m, a);
-                    // c_nl.push(numerical_c_nlm);
 
                     c_nl.push(c_nlm(&sphr_nbrs, &rbfs, n, l, m, sigma_at));
                 } // m


### PR DESCRIPTION
Totally 4 places are changed in this pr:

1. the usage of command line parser "clap" is updated with its version 4 features.
2. add a test for examining the rotation invariance of soap (in main.rs, function "test_rotate")
3. (Important) The parameters "theta" and "phi" are exchanged in the function "to_polar". Since I think in the way you write the function "sphr_harm", "theta" should be the one that  towards the positive Z axis. (Note that this exchange reduce the loss in the rotation invariance test )
4. Multiple neighbour elements can be selected now, by arg "--species" or "-s"